### PR TITLE
加强命令路由权限并修复前端响应/渲染风险

### DIFF
--- a/frontend/src/components/ArtifactSharePage.tsx
+++ b/frontend/src/components/ArtifactSharePage.tsx
@@ -200,7 +200,7 @@ const ArtifactSharePage: React.FC = () => {
           <div className="artifact-html-content rounded-xl overflow-hidden shadow-lg">
             <iframe
               srcDoc={DOMPurify.sanitize(artifact.content)}
-              sandbox="allow-scripts allow-same-origin"
+              sandbox=""
               className="w-full h-[600px] border-0 bg-white rounded-xl"
             />
           </div>
@@ -211,7 +211,7 @@ const ArtifactSharePage: React.FC = () => {
           <div className="artifact-svg-content rounded-xl overflow-hidden shadow-lg bg-white">
             <iframe
               srcDoc={`<html><body style="margin:0;display:flex;align-items:center;justify-content:center;min-height:100vh;background:#fff">${DOMPurify.sanitize(artifact.content, { USE_PROFILES: { svg: true, svgFilters: true } })}</body></html>`}
-              sandbox="allow-same-origin"
+              sandbox=""
               className="w-full h-[500px] border-0 rounded-xl"
             />
           </div>

--- a/frontend/src/utils/fetchWithFallback.ts
+++ b/frontend/src/utils/fetchWithFallback.ts
@@ -7,13 +7,11 @@ export async function fetchWithFallback(input: string, init?: RequestInit) {
     const res = await fetch(url, init);
     if (!res.ok) throw new Error('Primary API failed');
     const contentType = res.headers.get('content-type');
-    if (contentType && contentType.includes('application/json')) {
-      const data = await res.json();
-      return res;
-    } else {
+    if (!contentType || !contentType.includes('application/json')) {
       const text = await res.text();
       throw new Error('API 响应不是 JSON，实际返回：' + text.slice(0, 100));
     }
+    return res;
   } catch (e) {
     // 仅开发环境降级
     if (import.meta.env.DEV && apiUrl && !url.startsWith('http://localhost:3000')) {

--- a/src/routes/commandRoutes.ts
+++ b/src/routes/commandRoutes.ts
@@ -7,6 +7,14 @@ import { commandService } from "../services/commandService";
 
 const router = Router();
 
+const ensureAdmin = (req: any, res: any): boolean => {
+  if (!req.user || req.user.role !== "admin") {
+    res.status(403).json({ error: "需要管理员权限" });
+    return false;
+  }
+  return true;
+};
+
 /**
  * @openapi
  * /command/y:
@@ -27,13 +35,12 @@ const router = Router();
  *       200:
  *         description: 添加命令结果
  */
-router.post("/y", commandLimiter, async (req, res) => {
+router.post("/y", commandLimiter, authenticateToken, async (req, res) => {
   const { command, password } = req.body;
 
-  console.log("🔐 [CommandManager] 密码验证请求:");
-  console.log("   接收到的密码:", password);
-  console.log("   期望的密码:", config.adminPassword);
-  console.log("   密码匹配:", password === config.adminPassword);
+  if (!ensureAdmin(req, res)) {
+    return;
+  }
 
   // 验证密码
   if (password !== config.adminPassword) {
@@ -158,7 +165,11 @@ router.get("/q", commandLimiter, authenticateToken, async (req, res) => {
  *       200:
  *         description: 移除命令结果
  */
-router.post("/p", (req, res) => {
+router.post("/p", commandLimiter, authenticateToken, (req, res) => {
+  if (!ensureAdmin(req, res)) {
+    return;
+  }
+
   const { command } = req.body;
   const result = commandService.removeCommand(command);
   return res.json(result);
@@ -196,6 +207,10 @@ router.post("/p", (req, res) => {
 router.post("/execute", commandLimiter, authenticateToken, async (req, res) => {
   try {
     const { command, password } = req.body;
+
+    if (!ensureAdmin(req, res)) {
+      return;
+    }
 
     // 验证密码
     if (password !== config.adminPassword) {


### PR DESCRIPTION
### Motivation
- 修补命令管理相关的授权与敏感信息泄露风险，避免普通用户借接口或日志滥用管理员能力。 
- 修复前端在降级请求与共享制品渲染流程中的逻辑/安全问题，防止响应体被提前消费以及 iframe 导致的 XSS/同源滥用风险。

### Description
- 在命令路由中新增统一的管理员校验 `ensureAdmin` 并强制对 `/command/y`、`/command/p`、`/command/execute` 使用 `authenticateToken` + 管理员权限检查，避免非管理员执行或移除命令。 
- 移除命令提交路径中打印明文/期望管理员密码的调试日志，防止敏感信息泄露。 
- 修复 `frontend/src/utils/fetchWithFallback.ts` 中的响应处理逻辑，改为只检测 `content-type` 而不提前 `res.json()` 消耗响应体，保证调用方可正常读取响应。 
- 收紧 `frontend/src/components/ArtifactSharePage.tsx` 中 HTML/SVG 的 `iframe` sandbox 权限，移除 `allow-scripts` / `allow-same-origin`，降低用户内容在 iframe 中执行脚本或同源滥用的风险。

### Testing
- 已在后端运行类型检查 `npx tsc --noEmit`（backend）并通过。 
- 已在前端运行类型检查 `npx tsc --noEmit`（frontend）并通过。 
- 针对命令路由的单测 `npx jest src/tests/commandRoutes.test.ts --runInBand` 在当前环境下未通过，失败原因为测试运行器/依赖层的 Jest instrumentation 问题（`minimatch is not a function`），该问题出现在测试工具链/依赖中，与本次代码改动无关。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b5617392548324bd4db293a8bc81f1)